### PR TITLE
Migrate Android to built-in Kotlin (min Flutter 3.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+- Updates minimum supported SDK version to Flutter 3.44 / Dart 3.12
+- [Android] Migrates to built-in Kotlin (applies the Kotlin Gradle Plugin only on AGP < 9)
+
 ## 2.1.1
 
 - [Android] Updated compileSdkVersion to 36, Gradle to 8.14 and Java/Kotlin compatibility to version 17

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,12 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -38,10 +43,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-    
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'
@@ -52,6 +53,12 @@ android {
     }
     lintOptions {
         disable 'InvalidPackage'
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_image_utilities
 description: Image file related utilities for saving an image as JPEG with the specified quality and size and for getting image properties.
-version: 2.1.1
+version: 2.2.0
 homepage: https://github.com/kineapps/flutter_image_utilities
 repository: https://github.com/kineapps/flutter_image_utilities
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: ">=1.12.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Apply the Kotlin Gradle Plugin only on AGP < 9; built-in Kotlin handles AGP 9+ (official Flutter plugin-authors migration).
- Replace `kotlinOptions` with an unconditional `kotlin { compilerOptions { jvmTarget = JVM_17 } }` block.
- Raise minimum SDK to Flutter 3.44 / Dart 3.12; bump version to 2.2.0.

## Test plan
- Verified a consuming app builds with `flutter build apk` on Flutter 3.44 / AGP 8.11.1 (kotlin-android still applied on AGP 8.x; behavior unchanged).
- `flutter pub get` resolves on Flutter 3.44 / Dart 3.12.